### PR TITLE
Fix instantiation when running as subcontent

### DIFF
--- a/src/scripts/components/Scene/Scene.js
+++ b/src/scripts/components/Scene/Scene.js
@@ -75,9 +75,23 @@ export default class Scene extends React.Component {
       return;
     }
 
+    let params = {};
+    if (this.context.parent instanceof H5PEditor.Form) {
+      // Content is run standalone
+      params = this.context.parent.params;
+    }
+    else if (this.context.parent instanceof H5PEditor.Library) {
+      // Content is run as subcontent
+      params = this.context.parent.params.params;
+    }
+    else {
+      // Should never happen
+      console.error('Virtual Tour: Parent is not main form or library');
+    }
+
     this.preview = initializeThreeSixtyPreview(
       this.previewRef.current,
-      this.context.parent.params,
+      params,
       {
         edit: this.context.t('edit'),
         delete: this.context.t('delete'),


### PR DESCRIPTION
When merged in, will stop making assumptions about what the parent library is to retrieve parameters. Fixes https://github.com/codefluegel/h5p-virtual-3D-tour/issues/4